### PR TITLE
Use token centers to find positioning

### DIFF
--- a/dist/scripts/marker.js
+++ b/dist/scripts/marker.js
@@ -24,6 +24,10 @@ export class Marker {
         }
     }
 
+    get ratio() {
+        return 1.5;
+    }
+
     setId(tId){
         this.id = tId;
         this.tile_data.flags.id = tId;
@@ -44,9 +48,21 @@ export class Marker {
         })
         this.pendingUpdate = true
     }
-    
-    move(){
-        throw new Error("Method 'move()' must be implemented.");
+
+    move() {
+        // Get the real token from the combat tracker
+        let tokenId = game.combats.get(this.combat_id).combatant.tokenId;
+        let token = canvas.tokens.get(tokenId);
+        if (token) {
+            let dims = this.getImageDimensions(token, this.ratio)
+            let center = this.getImageLocation(token, dims)
+            this.update({
+                width: dims.w,
+                height: dims.h,
+                x: center.x,
+                y: center.y
+            });
+        }
     }
 
     shrink(){
@@ -70,7 +86,12 @@ export class Marker {
         return this.scene_id + ' ' + this.id + ' ' + this.tile
     }
 
-    // the below methods should really be in a seperate Combat marker Class
+    /**
+     * Get the desired dimensions of the marker based on the token
+     * @param {Token} token - the token to size the marker to
+     * @param {number} ratio - the scale ratio
+     * @returns {Object} - h, w pixel dimensions
+     */
     getImageDimensions(token, ratio) {
         let newWidth = 0;
         let newHeight = 0;
@@ -78,38 +99,29 @@ export class Marker {
 
         switch (scene.data.gridType) {
             case 2: case 3: // Hex Rows
-                newWidth = newHeight = token.height * ratio;
+                newWidth = newHeight = token.data.height * ratio;
                 break;
             case 4: case 5: // Hex Columns
-                newWidth = newHeight = token.width * ratio;
+                newWidth = newHeight = token.data.width * ratio;
                 break;
             default: // Gridless and Square
-                newWidth = token.width * ratio;
-                newHeight = token.height * ratio;
+                newWidth = token.data.width * ratio;
+                newHeight = token.data.height * ratio;
                 break;
         }
 
         return { w: newWidth * scene.data.grid, h: newHeight * scene.data.grid};
     }
 
-    getImageLocation(token, ratio) {
-        let newX = 0;
-        let newY = 0;
-        let scene  = game.scenes.get(this.scene_id)
-        switch (scene.data.gridType) {
-            case 2: case 3: // Hex Rows
-                newX = token.x - ((((ratio - 1) * token.width)/2) * scene.data.grid);
-                newY = token.y - ((((ratio - 1) * token.height)/2) * scene.data.grid);
-                break;
-            case 4: case 5: // Hex Columns
-                newX = token.x - ((((ratio - 1) * token.width)/2) * scene.data.grid);
-                newY = token.y - ((((ratio - 1) * token.height)/2) * scene.data.grid);
-                break;
-            default: // Gridless and Square
-                newX = token.x - ((((ratio - 1) * token.width)/2) * scene.data.grid);
-                newY = token.y - ((((ratio - 1) * token.height)/2) * scene.data.grid);
-                break;
-        }
+    /**
+     * Get location relative to token center
+     * @param {Token} token - token to center the marker on
+     * @param {Object} dims - dimensions of this marker
+     * @returns {Object} x, y coords to place the marker
+     */
+    getImageLocation(token, dims) {
+        let newX = token.center.x - dims.w / 2;
+        let newY = token.center.y - dims.h / 2;
         return { x: newX, y: newY };
     }
 }

--- a/dist/scripts/smmarker.js
+++ b/dist/scripts/smmarker.js
@@ -8,17 +8,18 @@ export class StartMarker extends Marker {
 
     constructor(scene_id, combat_id, id, tile_data) {
         super(scene_id, combat_id, id, tile_data)
-        this.ratio=1.5
         if (this.pendingCreate){
             this.tile_data = this.create()
         }
     }
 
-    create(){
-        let token = game.combats.get(this.combat_id).combatant.token
+    create() {
+        // Get the real token from the combat tracker
+        let tokenId = game.combats.get(this.combat_id).combatant.tokenId;
+        let token = canvas.tokens.get(tokenId);
         if (token){
-            let dims = this.getImageDimensions(token, this.ratio)
-            let center = this.getImageLocation(token, this.ratio)
+            let dims = this.getImageDimensions(token, this.ratio);
+            let center = this.getImageLocation(token, dims);
             return {
                 img: Settings.getChoosenSMImagePath(),
                 width: dims.w,
@@ -49,21 +50,5 @@ export class StartMarker extends Marker {
                     id: this.id}
             }
         } 
-    }
-
-    move(update){
-        let token = game.combats.get(this.combat_id).combatant.token
-        if(!update){update = {}}
-        if (token){
-            if(!update.x){update.x = token.x}
-            if(!update.y){update.y = token.y}
-            let dims = this.getImageDimensions(token, this.ratio)
-            let center = this.getImageLocation(token, this.ratio)
-            this.update({
-                width: dims.w,
-                height: dims.h,
-                x: center.x,
-                y: center.y})
-        }
     }
 }

--- a/dist/scripts/tmmarker.js
+++ b/dist/scripts/tmmarker.js
@@ -8,17 +8,23 @@ export class TurnMarker extends Marker {
 
     constructor(scene_id, combat_id, id, tile_data) {
         super(scene_id, combat_id, id, tile_data)
-        //this.ratio = Settings.getRatio()
         if (this.pendingCreate){
             this.tile_data = this.create()
         }
     }
 
-    create(){
-        let token = game.combats.get(this.combat_id).combatant.token
+    /* @override */
+    get ratio() {
+        return Settings.getRatio();
+    }
+
+    create() {
+        // Get the real token from the combat tracker
+        let tokenId = game.combats.get(this.combat_id).combatant.tokenId;
+        let token = canvas.tokens.get(tokenId);
         if (token){
-            let dims = this.getImageDimensions(token, Settings.getRatio())
-            let center = this.getImageLocation(token, Settings.getRatio())
+            let dims = this.getImageDimensions(token, this.ratio);
+            let center = this.getImageLocation(token, dims);
             return {
                 img: Settings.getChoosenTMImagePath(),
                 width: dims.w,
@@ -49,21 +55,5 @@ export class TurnMarker extends Marker {
                     id: this.id}
             }
         }
-    }
-
-    move(update, ratio){
-        let token = game.combats.get(this.combat_id).combatant.token
-        if(!update){update = {}}
-        if (token){
-            if(!update.x){update.x = token.x}
-            if(!update.y){update.y = token.y}
-            let dims = this.getImageDimensions(token, ratio)
-            let center = this.getImageLocation(token, ratio)
-            this.update({
-                width: dims.w,
-                height: dims.h,
-                x: center.x,
-                y: center.y})
-        } 
     }
 }


### PR DESCRIPTION
Changes Marker.getImageDimensions to use the actual token object pulled
from the canvas. This is to conform the change of the type of the token
var in the move() and create() methods.

Changes Marker.getImageLocation to use the actual token and the
dimensions of the marker image. Using the actual token rather than
token.data allows access to Token.center allowing more straightforward
positioning of the marker.

Moves the move method to the base class since both versions have
identical logic.

Adds a getter for ratio to avoud having to pass it around. On the base
Marker class, returns fixed 1.5. StartMarker inherits, and TurnMarker
overrides to return the value from settings.

Fixes #6